### PR TITLE
Fix schema execute context parameter

### DIFF
--- a/graphene_tornado/tornado_graphql_handler.py
+++ b/graphene_tornado/tornado_graphql_handler.py
@@ -267,7 +267,7 @@ class TornadoGraphQLHandler(web.RequestHandler):
 
     @property
     def context(self):
-        return None
+        return self.request
 
     @staticmethod
     def instantiate_middleware(middlewares):

--- a/graphene_tornado/tornado_graphql_handler.py
+++ b/graphene_tornado/tornado_graphql_handler.py
@@ -220,7 +220,7 @@ class TornadoGraphQLHandler(web.RequestHandler):
                 root_value=self.root_value,
                 variable_values=variables,
                 operation_name=operation_name,
-                context_value=self.request,
+                context_value=self.context,
                 middleware=self.middleware,
                 executor=self.executor or TornadoExecutor(),
                 return_promise=True


### PR DESCRIPTION
Fix that allows user to provide custom context value by overriding TornadoGraphQLHandler.context property.

Example:
```
class MyTornadoGraphQLHandler(TornadoGraphQLHandler):

    @property
    def context(self):
        return {'my_value': 'test}
```