### PR TITLE
Use a range for jinja2 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 six>=1.10.0
 graphene>=2.0.1
-Jinja2==2.10.1
+Jinja2>=2.10.1, <2.11.0
 tornado>=5.1.0
 werkzeug==0.12.2


### PR DESCRIPTION
Hi,

Thanks for fixing the issue with Jinja2 so quickly.

What about using a range for this dependency, instead of using a single version? That may avoid other incompatibility issues with other libraries in the future too.

The range I used in this pull request is the same we (I work with @dwsutherland who submitted the other pull request) adopted in [cylc](https://github.com/cylc/cylc/pull/2990/files#diff-2eeaed663bd0d25b7e608891384b7298R106), following what was used by [Apache Airflow](https://github.com/apache/airflow/blob/6cc7712442cf23c7f846b73030c79ba12fdf4a0e/setup.py#L329) too.

Cheers