### PR TITLE
Pin graphene

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
 
     install_requires=[
         'six>=1.10.0',
-        'graphene>=2.1',
+        'graphene>=2.1,<3',
         'Jinja2>=2.10.1',
         'tornado>=5.1.0',
         'werkzeug==0.12.2'


### PR DESCRIPTION
Graphene v3 will be released soon and it will contain breaking changes. This PR pins Graphene to versions less than 3 so that it doesn't accidentally install v3 until the library can support it.