### PR TITLE
Revert "Add allow_subscriptions to the TornadoGraphQLHandler"

### DIFF
--- a/graphene_tornado/tornado_graphql_handler.py
+++ b/graphene_tornado/tornado_graphql_handler.py
@@ -53,7 +53,7 @@ class TornadoGraphQLHandler(web.RequestHandler):
     extension_stack = GraphQLExtensionStack()
 
     def initialize(self, schema=None, executor=None, middleware=None, root_value=None, graphiql=False, pretty=False,
-                   batch=False, backend=None, extensions=None, allow_subscriptions=False):
+                   batch=False, backend=None, extensions=None):
         super(TornadoGraphQLHandler, self).initialize()
 
         self.schema = schema
@@ -75,7 +75,6 @@ class TornadoGraphQLHandler(web.RequestHandler):
         self.graphiql = graphiql
         self.batch = batch
         self.backend = backend or get_default_backend()
-        self.allow_subscriptions = allow_subscriptions
 
     @property
     def context(self):
@@ -296,8 +295,7 @@ class TornadoGraphQLHandler(web.RequestHandler):
                 context=self.context,
                 middleware=self.get_middleware(),
                 executor=self.executor or TornadoExecutor(),
-                return_promise=True,
-                allow_subscriptions=self.allow_subscriptions
+                return_promise=True
             )
             yield execution_ended()
         except Exception as e:


### PR DESCRIPTION
Reverts graphql-python/graphene-tornado#28

Looking at #27 , looks like `TornadoGraphQLHandler` does not understand subscriptions by design. So I think this can be undone - even though harmless, at least this should prevent other users of trying to use `TornadoGraphQLHandler` in subscriptions, and instead use a `WebSocketHandler`.

@ewhauser, mea culpa, sorry. This flag should not have caused any issue for users updating to 2.3.0, and neither should its removal in a subsequent release :+1: just more to prevent confusion.

Bruno